### PR TITLE
Send pedal position on change

### DIFF
--- a/examples/Pedals/PedalsJoystick/PedalsJoystick.ino
+++ b/examples/Pedals/PedalsJoystick/PedalsJoystick.ino
@@ -66,6 +66,12 @@ void setup() {
 void loop() {
 	pedals.update();
 
+	if (pedals.positionChanged()) {
+		updatePedals();
+	}
+}
+
+void updatePedals() {
 	if (pedals.hasPedal(SimRacing::Gas)) {
 		int gasPedal = pedals.getPosition(SimRacing::Gas, 0, ADC_Max);
 		Joystick.setRyAxis(gasPedal);

--- a/examples/Pedals/PedalsJoystick/PedalsJoystick.ino
+++ b/examples/Pedals/PedalsJoystick/PedalsJoystick.ino
@@ -61,17 +61,19 @@ void setup() {
 	Joystick.setZAxisRange(0, ADC_Max);
 	Joystick.setRxAxisRange(0, ADC_Max);
 	Joystick.setRyAxisRange(0, ADC_Max);
+
+	updateJoystick();  // send initial state
 }
 
 void loop() {
 	pedals.update();
 
 	if (pedals.positionChanged()) {
-		updatePedals();
+		updateJoystick();
 	}
 }
 
-void updatePedals() {
+void updateJoystick() {
 	if (pedals.hasPedal(SimRacing::Gas)) {
 		int gasPedal = pedals.getPosition(SimRacing::Gas, 0, ADC_Max);
 		Joystick.setRyAxis(gasPedal);

--- a/examples/Pedals/PedalsJoystick/PedalsJoystick.ino
+++ b/examples/Pedals/PedalsJoystick/PedalsJoystick.ino
@@ -49,6 +49,7 @@ Joystick_ Joystick(
 	false, false, false, false, false, false);  // no other axes
 
 const int ADC_Max = 1023;  // max value of the analog inputs, 10-bit on AVR boards
+const bool AlwaysSend = false;  // override the position checks, *always* send data constantly
 
 
 void setup() {
@@ -68,7 +69,7 @@ void setup() {
 void loop() {
 	pedals.update();
 
-	if (pedals.positionChanged()) {
+	if (pedals.positionChanged() || AlwaysSend) {
 		updateJoystick();
 	}
 }

--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -285,26 +285,6 @@ int AnalogInput::getPositionRaw() const {
 	return this->position;
 }
 
-bool AnalogInput::inRange() const {
-	return inRange(this->getPositionRaw());
-}
-
-bool AnalogInput::inRange(int p) const {
-	bool output;
-	
-	// In 'normal' orientation, we are within range if the position
-	// is above the min and below the max.
-	if (!isInverted()) {
-		output = (p >= getMin() && p <= getMax());
-	}
-	// In 'inverted' orientation, we are within range if the position
-	// is below the min and above the max.
-	else {
-		output = (p >= getMax() && p <= getMin());
-	}
-	return output;
-}
-
 bool AnalogInput::isInverted() const {
 	return (this->cal.min > this->cal.max);  // inverted if min is greater than max
 }

--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -285,6 +285,26 @@ int AnalogInput::getPositionRaw() const {
 	return this->position;
 }
 
+bool AnalogInput::inRange() const {
+	return inRange(this->getPositionRaw());
+}
+
+bool AnalogInput::inRange(int p) const {
+	bool output;
+	
+	// In 'normal' orientation, we are within range if the position
+	// is above the min and below the max.
+	if (!isInverted()) {
+		output = (p >= getMin() && p <= getMax());
+	}
+	// In 'inverted' orientation, we are within range if the position
+	// is below the min and above the max.
+	else {
+		output = (p >= getMax() && p <= getMin());
+	}
+	return output;
+}
+
 bool AnalogInput::isInverted() const {
 	return (this->cal.min > this->cal.max);  // inverted if min is greater than max
 }

--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -268,10 +268,33 @@ AnalogInput::AnalogInput(uint8_t p)
 
 bool AnalogInput::read() {
 	bool changed = false;
+
 	if (Pin != NOT_A_PIN) {
-		const int current = this->position;
+		const int previous = this->position;
 		this->position = analogRead(Pin);
-		if (current != this->position) changed = true;
+
+		// check if value is different for 'changed' flag
+		if (previous != this->position) {
+
+			const int rMin = isInverted() ? getMax() : getMin();
+			const int rMax = isInverted() ? getMin() : getMax();
+
+			if (
+				// if the previous value was under the minimum range
+				// and the current value is as well, no change
+				!(previous < rMin && this->position < rMin) && 
+
+				// if the previous value was over the maximum range
+				// and the current value is as well, no change
+				!(previous > rMax && this->position > rMax)
+			)
+			{
+				// otherwise, the current value is either within the
+				// range limits *or* it has changed from one extreme
+				// to the other. Either way, mark it changed!
+				changed = true;
+			}
+		}
 	}
 	return changed;
 }

--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -311,7 +311,11 @@ void AnalogInput::setCalibration(AnalogInput::Calibration newCal) {
 //#########################################################
 
 Pedals::Pedals(AnalogInput* dataPtr, uint8_t nPedals, uint8_t detectPin)
-	: pedalData(dataPtr), NumPedals(nPedals), detector(detectPin)
+	: 
+	pedalData(dataPtr),
+	NumPedals(nPedals),
+	detector(detectPin),
+	changed(false)
 {}
 
 void Pedals::begin() {
@@ -319,7 +323,7 @@ void Pedals::begin() {
 }
 
 bool Pedals::update() {
-	bool changed = false;
+	changed = false;
 
 	detector.poll();
 	if (detector.getState() == DeviceConnection::Connected) {

--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -487,7 +487,7 @@ LogitechPedals::LogitechPedals(uint8_t gasPin, uint8_t brakePin, uint8_t clutchP
 	// taken from calibrating my own pedals. the springs are pretty stiff so while
 	// this covers the whole travel range, users may want to back it down for casual
 	// use (esp. for the brake travel)
-	this->setCalibration({ 904, 48 }, { 949, 286 }, { 881, 59 });
+	this->setCalibration({ 904, 48 }, { 944, 286 }, { 881, 59 });
 }
 
 LogitechDrivingForceGT_Pedals::LogitechDrivingForceGT_Pedals(uint8_t gasPin, uint8_t brakePin, uint8_t detectPin)

--- a/src/SimRacing.h
+++ b/src/SimRacing.h
@@ -332,6 +332,13 @@ namespace SimRacing {
 		int getNumPedals() const { return this->NumPedals; }
 
 		/**
+		* Checks whether the current pedal positions have changed since the last update.
+		*
+		* @return 'true' if position has changed, 'false' otherwise
+		*/
+		bool positionChanged() const { return changed; }
+
+		/**
 		* Calibrate a pedal's min/max values for rescaling.
 		* 
 		* @param pedal the pedal to set the calibration of
@@ -362,6 +369,7 @@ namespace SimRacing {
 		AnalogInput* pedalData;     ///< pointer to the pedal data
 		const int NumPedals;        ///< number of pedals managed by this class
 		DeviceConnection detector;  ///< detector instance for checking if the pedals are connected
+		bool changed;               ///< whether the pedal position has changed since the previous update
 	};
 
 

--- a/src/SimRacing.h
+++ b/src/SimRacing.h
@@ -176,6 +176,23 @@ namespace SimRacing {
 		int getMax() const { return this->cal.max; }
 
 		/**
+		* Checks whether the current position is within the calibrated
+		* range of the axis.
+		*
+		* @return 'true' if position is within range, 'false' otherwise
+		*/
+		bool inRange() const;
+
+		/**
+		* Checks whether a given input value is within the calibrated
+		* range of the axis.
+		*
+		* @param p position value to test
+		* @return 'true' if test value is within range, 'false' otherwise
+		*/
+		bool inRange(int p) const;
+
+		/**
 		* Check whether the axis is inverted or not.
 		*
 		* @return 'true' if the axis is inverted, 'false' otherwise

--- a/src/SimRacing.h
+++ b/src/SimRacing.h
@@ -176,23 +176,6 @@ namespace SimRacing {
 		int getMax() const { return this->cal.max; }
 
 		/**
-		* Checks whether the current position is within the calibrated
-		* range of the axis.
-		*
-		* @return 'true' if position is within range, 'false' otherwise
-		*/
-		bool inRange() const;
-
-		/**
-		* Checks whether a given input value is within the calibrated
-		* range of the axis.
-		*
-		* @param p position value to test
-		* @return 'true' if test value is within range, 'false' otherwise
-		*/
-		bool inRange(int p) const;
-
-		/**
 		* Check whether the axis is inverted or not.
 		*
 		* @return 'true' if the axis is inverted, 'false' otherwise


### PR DESCRIPTION
These changes make it so that pedal data in the `PedalsJoystick` example is only sent whenever the pedals actually move. The goal is to avoid spamming games with pedal input and grabbing focus away from other input devices like wheels or mice. The latter of which makes it really difficult to actually *set up* the pedals in certain games. This can be overridden with an option in the example to restore its previous behavior.

Because of an underlying change to the `AnalogInput` class, all classes that use an ADC input will only report changes if the ADC input is within the calibration range (to avoid saying "data changed" when it's outside of the range we are reporting). The `Handbrake` class is the one most noticeably affected.

Pedal serial calibration now includes deadzone options for the start and end of the travel range. The former should reduce issues with pedals being always "on", the latter should reduce issues with being unable to get the pedal to 100%. Both are set at low values by default (1% and 2.5%, respectively). These *only* affect serial (conversational) calibration. Applied calibration is unmodified.

This also slightly adjusts the calibration of the Logitech pedals' brake, which was registering a constant low input during more thorough testing.