### PR TITLE
Send handbrake position on change

### DIFF
--- a/examples/Handbrake/HandbrakeJoystick/HandbrakeJoystick.ino
+++ b/examples/Handbrake/HandbrakeJoystick/HandbrakeJoystick.ino
@@ -45,6 +45,7 @@ Joystick_ Joystick(
 	false, false, false, false, false, false, false, false);  // no other axes
 
 const int ADC_Max = 1023;  // max value of the analog inputs, 10-bit on AVR boards
+const bool AlwaysSend = false;  // override the position checks, *always* send data constantly
 
 
 void setup() {
@@ -53,13 +54,20 @@ void setup() {
 	// if you have one, your calibration line should go here
 	
 	Joystick.begin(false);  // 'false' to disable auto-send
-
 	Joystick.setZAxisRange(0, ADC_Max);
+
+	updateJoystick();  // send initial state
 }
 
 void loop() {
 	handbrake.update();
 
+	if (handbrake.positionChanged() || AlwaysSend) {
+		updateJoystick();
+	}
+}
+
+void updateJoystick() {
 	int pos = handbrake.getPosition(0, ADC_Max);
 	Joystick.setZAxis(pos);
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -70,6 +70,7 @@ setCalibration	KEYWORD2
 
 getPosition	KEYWORD2
 getPositionRaw	KEYWORD2
+positionChanged	KEYWORD2
 
 hasPedal	KEYWORD2
 
@@ -104,6 +105,7 @@ serialCalibration	KEYWORD2
 
 getPosition	KEYWORD2
 getPositionRaw	KEYWORD2
+positionChanged	KEYWORD2
 
 setCalibration	KEYWORD2
 serialCalibration	KEYWORD2

--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -987,7 +987,10 @@ LogitechShifter::LogitechShifter(uint8_t pinX, uint8_t pinY, uint8_t pinRev, uin
 //#########################################################
 
 Handbrake::Handbrake(uint8_t pinAx, uint8_t detectPin) 
-	: analogAxis(pinAx), detector(detectPin)
+	: 
+	analogAxis(pinAx),
+	detector(detectPin),
+	changed(false)
 {}
 
 void Handbrake::begin() {
@@ -995,7 +998,7 @@ void Handbrake::begin() {
 }
 
 bool Handbrake::update() {
-	bool changed = false;
+	changed = false;
 
 	detector.poll();
 	if (detector.getState() == DeviceConnection::Connected) {

--- a/src/SimRacing.h
+++ b/src/SimRacing.h
@@ -716,6 +716,13 @@ namespace SimRacing {
 		*/
 		int getPositionRaw() const;
 
+		/**
+		* Checks whether the handbrake's position has changed since the last update.
+		*
+		* @return 'true' if the position has changed, 'false' otherwise
+		*/
+		bool positionChanged() const { return changed; }
+
 		/// @copydoc AnalogInput::setCalibration()
 		void setCalibration(AnalogInput::Calibration newCal);
 
@@ -728,6 +735,7 @@ namespace SimRacing {
 	private:
 		AnalogInput analogAxis;     ///< axis data for the handbrake's position
 		DeviceConnection detector;  ///< detector instance for checking if the handbrake is connected
+		bool changed;               ///< whether the handbrake position has changed since the previous update
 	};
 
 


### PR DESCRIPTION
As a follow-up to #3, this limits the `HandbrakeJoystick` example so that it only sends positional data when the handbrake changes.

It also adds the `positionChanged()` function name to the Arduino IDE keywords map, which should have been included in the previous PR.