### PR TITLE
Sim Racing Shield Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Run one of the library examples in the Arduino IDE by going to `File -> Examples
 * [Logitech Three Pedal Peripheral (Gas, Brake, Clutch)](http://dmadison.github.io/Sim-Racing-Arduino/docs/logitech_pedals.html)
 * [Logitech Driving Force Shifter](http://dmadison.github.io/Sim-Racing-Arduino/docs/logitech_shifter.html)
 
+## Adapters
+
+Open source shields are available to connect the [Logitech Three Pedal Peripheral](http://dmadison.github.io/Sim-Racing-Arduino/docs/logitech_pedals.html) and the [Logitech Driving Force Shifter](http://dmadison.github.io/Sim-Racing-Arduino/docs/logitech_shifter.html) to a [SparkFun Pro Micro](https://github.com/sparkfun/Pro_Micro). The design comes with a 3D printable case and custom board files so that the adapter appears with a custom identity and "Sim Racing" name over USB. You can use these shields to build an inexpensive USB HID adapter.
+
+You can find all of the necessary files in [the project repository](https://github.com/dmadison/Sim-Racing-Shields).
+
 ## License
 
 This library is licensed under the terms of the [GNU Lesser General Public License (LGPL)](https://www.gnu.org/licenses/lgpl.html), either version 3 of the License, or (at your option) any later version. See the [LICENSE](https://github.com/dmadison/Sim-Racing-Arduino/blob/master/LICENSE) file for more information.

--- a/docs/pages/devices/logitech_pedals.md
+++ b/docs/pages/devices/logitech_pedals.md
@@ -6,6 +6,12 @@ The 2-pedal peripheral included with the [Logitech Driving Force GT wheel](https
 
 See the PedalsPrint.ino and PedalsJoystick.ino examples for reference.
 
+## Adapters
+
+An open source shield is available to connect the three pedal peripheral to a [SparkFun Pro Micro](https://github.com/sparkfun/Pro_Micro). The design comes with a 3D printable case and custom board files so that the device appears as "Sim Racing Pedals" over USB. You can use this shield to build an inexpensive USB HID adapter.
+
+You can find all of the necessary files in [the project repository](https://github.com/dmadison/Sim-Racing-Shields). Please note that this shield is *not* compatible with the two pedal peripheral.
+
 ## Connector
 
 | ![DE-9](DE9_Male.svg) | ![DE-9_Female](DE9_Female.svg) |

--- a/docs/pages/devices/logitech_shifter.md
+++ b/docs/pages/devices/logitech_shifter.md
@@ -4,6 +4,12 @@ The [Logitech Driving Force Shifter](https://www.logitechg.com/en-us/products/dr
 
 See the ShiftPrint.ino and ShiftJoystick.ino examples for reference.
 
+## Adapters
+
+An open source shield is available to connect the shifter to a [SparkFun Pro Micro](https://github.com/sparkfun/Pro_Micro). The design comes with a 3D printable case and custom board files so that the device appears as a "Sim Racing Shifter" over USB. You can use this shield to build an inexpensive USB HID adapter.
+
+You can find all of the necessary files in [the project repository](https://github.com/dmadison/Sim-Racing-Shields).
+
 ## Connector
 
 | ![DE-9_Male](DE9_Male.svg) | ![DE-9_Female](DE9_Female.svg) |

--- a/examples/Pedals/PedalsJoystick/PedalsJoystick.ino
+++ b/examples/Pedals/PedalsJoystick/PedalsJoystick.ino
@@ -36,6 +36,7 @@ const int Pin_Brake  = A1;
 const int Pin_Clutch = A0;
 
 SimRacing::LogitechPedals pedals(Pin_Gas, Pin_Brake, Pin_Clutch);
+//SimRacing::LogitechPedals pedals(PEDAL_SHIELD_V1_PINS);
 
 Joystick_ Joystick(
 	JOYSTICK_DEFAULT_REPORT_ID,          // default report (no additional pages)

--- a/examples/Pedals/PedalsPrint/PedalsPrint.ino
+++ b/examples/Pedals/PedalsPrint/PedalsPrint.ino
@@ -32,6 +32,7 @@ const int Pin_Brake  = A1;
 const int Pin_Clutch = A0;
 
 SimRacing::LogitechPedals pedals(Pin_Gas, Pin_Brake, Pin_Clutch);
+//SimRacing::LogitechPedals pedals(PEDAL_SHIELD_V1_PINS);
 
 
 void setup() {

--- a/examples/Shifter/ShiftJoystick/ShiftJoystick.ino
+++ b/examples/Shifter/ShiftJoystick/ShiftJoystick.ino
@@ -45,6 +45,7 @@ const int Pin_ShifterY   = A2;
 const int Pin_ShifterRev = 2;
 
 SimRacing::LogitechShifter shifter(Pin_ShifterX, Pin_ShifterY, Pin_ShifterRev);
+//SimRacing::LogitechShifter shifter(SHIFTER_SHIELD_V1_PINS);
 
 const int Gears[] = { 1, 2, 3, 4, 5, 6, -1 };
 const int NumGears = sizeof(Gears) / sizeof(Gears[0]);

--- a/examples/Shifter/ShiftPrint/ShiftPrint.ino
+++ b/examples/Shifter/ShiftPrint/ShiftPrint.ino
@@ -32,6 +32,7 @@ const int Pin_ShifterY   = A2;
 const int Pin_ShifterRev = 2;
 
 SimRacing::LogitechShifter shifter(Pin_ShifterX, Pin_ShifterY, Pin_ShifterRev);
+//SimRacing::LogitechShifter shifter(SHIFTER_SHIELD_V1_PINS);
 
 const unsigned long PrintSpeed = 1500;  // ms
 unsigned long lastPrint = 0;


### PR DESCRIPTION
Adds some info about the [Sim Racing Shields project](https://github.com/dmadison/Sim-Racing-Shields) to the documentation, for those looking to make their own adapters.

Also adds commented out lines declaring objects using the shield pin macros.