### PR TITLE
Adapter Tutorial Video Docs

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -261,7 +261,7 @@ TAB_SIZE               = 4
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                =
+ALIASES                = youtube_embed{1}="@htmlonly<div><div style=\"position:relative;padding-top:56.25%;\"><iframe src=\"\1\" title=\"YouTube video player\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen style=\"position:absolute;top:0;left:0;width:100%;height:100%;\"></iframe></div></div>@endhtmlonly"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/docs/pages/devices/logitech_pedals.md
+++ b/docs/pages/devices/logitech_pedals.md
@@ -8,9 +8,13 @@ See the PedalsPrint.ino and PedalsJoystick.ino examples for reference.
 
 ## Adapters
 
-An open source shield is available to connect the three pedal peripheral to a [SparkFun Pro Micro](https://github.com/sparkfun/Pro_Micro). The design comes with a 3D printable case and custom board files so that the device appears as "Sim Racing Pedals" over USB. You can use this shield to build an inexpensive USB HID adapter.
+@youtube_embed{https://www.youtube.com/embed/6Pu1qknGjy4}
 
-You can find all of the necessary files in [the project repository](https://github.com/dmadison/Sim-Racing-Shields). Please note that this shield is *not* compatible with the two pedal peripheral.
+The best way to connect to the pedals is to build your own DIY adapter using a female DE-9 connector. This is simple to make and does not require any modifications to the pedal base. The above video walks you through the process of wiring to an Arduino Leonardo. Be aware that the wiring is different between the 3-pedal and 2-pedal versions; the video does *not* apply to the 2-pedal version.
+
+If you want something more robust, an open source shield is available to connect the three pedal peripheral to a [SparkFun Pro Micro](https://github.com/sparkfun/Pro_Micro). The design comes with a 3D printable case and custom board files so that the device appears as "Sim Racing Pedals" over USB. You can use this shield to build an inexpensive USB HID adapter.
+
+You can find all of the necessary files in [the project repository](https://github.com/dmadison/Sim-Racing-Shields). Please note that this shield is also *not* compatible with the two pedal peripheral.
 
 ## Connector
 

--- a/docs/pages/devices/logitech_shifter.md
+++ b/docs/pages/devices/logitech_shifter.md
@@ -6,7 +6,11 @@ See the ShiftPrint.ino and ShiftJoystick.ino examples for reference.
 
 ## Adapters
 
-An open source shield is available to connect the shifter to a [SparkFun Pro Micro](https://github.com/sparkfun/Pro_Micro). The design comes with a 3D printable case and custom board files so that the device appears as a "Sim Racing Shifter" over USB. You can use this shield to build an inexpensive USB HID adapter.
+@youtube_embed{https://www.youtube.com/embed/ngXsOidoWhI}
+
+The best way to connect to the shifter is to build your own DIY adapter using a male DE-9 connector. This is simple to make and does not require any modifications to the shifter. The above video walks you through the process of wiring to an Arduino Leonardo.
+
+If you want something more robust, an open source shield is available to connect the shifter to a [SparkFun Pro Micro](https://github.com/sparkfun/Pro_Micro). The design comes with a 3D printable case and custom board files so that the device appears as a "Sim Racing Shifter" over USB. You can use this shield to build an inexpensive USB HID adapter.
 
 You can find all of the necessary files in [the project repository](https://github.com/dmadison/Sim-Racing-Shields).
 


### PR DESCRIPTION
Embeds the adapter tutorial videos in their relevant "Supported Devices" pages. This includes a Doxygen alias to make embedding future videos easier.