### PR TITLE
Tweak Logitech Shifter Calibration

### DIFF
--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -980,7 +980,7 @@ void AnalogShifter::serialCalibration(Stream& iface) {
 LogitechShifter::LogitechShifter(uint8_t pinX, uint8_t pinY, uint8_t pinRev, uint8_t detectPin)
 	: AnalogShifter(pinX, pinY, pinRev, detectPin)
 {
-	this->setCalibration({ 490, 440 }, { 253, 799 }, { 262, 86 }, { 460, 826 }, { 470, 76 }, { 664, 841 }, { 677, 77 }, 0.70, 0.50, 0.70);
+	this->setCalibration({ 490, 440 }, { 253, 799 }, { 262, 86 }, { 460, 826 }, { 470, 76 }, { 664, 841 }, { 677, 77 });
 }
 
 //#########################################################

--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -655,7 +655,7 @@ String Shifter::getGearString() const {
 */
 const float AnalogShifter::CalEngagementPoint = 0.70;
 const float AnalogShifter::CalReleasePoint = 0.50;
-const float AnalogShifter::CalEdgeOffset = 0.70;
+const float AnalogShifter::CalEdgeOffset = 0.60;
 
 AnalogShifter::AnalogShifter(uint8_t pinX, uint8_t pinY, uint8_t pinRev, uint8_t detectPin)
 	: 


### PR DESCRIPTION
Modifies the default Logitech shifter calibration for better compatibility with G27 shifters.

Closes #10.