### PR TITLE
Doxygen Fixes

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -209,7 +209,7 @@ SHORT_NAMES            = NO
 # description.)
 # The default value is: NO.
 
-JAVADOC_AUTOBRIEF      = NO
+JAVADOC_AUTOBRIEF      = YES
 
 # If the JAVADOC_BANNER tag is set to YES then doxygen will interpret a line
 # such as

--- a/examples/Handbrake/HandbrakeJoystick/HandbrakeJoystick.ino
+++ b/examples/Handbrake/HandbrakeJoystick/HandbrakeJoystick.ino
@@ -21,7 +21,7 @@
  */
 
  /**
- * @brief   Emulates the handbrake as a joystick over USB.
+ * @details Emulates the handbrake as a joystick over USB.
  * @example HandbrakeJoystick.ino
  */
 

--- a/examples/Handbrake/HandbrakePrint/HandbrakePrint.ino
+++ b/examples/Handbrake/HandbrakePrint/HandbrakePrint.ino
@@ -21,7 +21,7 @@
  */
 
  /**
- * @brief   Prints handbrake position percentage over Serial.
+ * @details Prints handbrake position percentage over Serial.
  * @example HandbrakePrint.ino
  */
 

--- a/examples/Pedals/PedalsJoystick/PedalsJoystick.ino
+++ b/examples/Pedals/PedalsJoystick/PedalsJoystick.ino
@@ -21,7 +21,7 @@
  */
 
  /**
- * @brief   Emulates the pedals as a joystick over USB.
+ * @details Emulates the pedals as a joystick over USB.
  * @example PedalsJoystick.ino
  */
 

--- a/examples/Pedals/PedalsPrint/PedalsPrint.ino
+++ b/examples/Pedals/PedalsPrint/PedalsPrint.ino
@@ -21,7 +21,7 @@
  */
 
  /**
- * @brief   Prints pedal position percentages over Serial.
+ * @details Prints pedal position percentages over Serial.
  * @example PedalsPrint.ino
  */
 

--- a/examples/Shifter/ShiftJoystick/ShiftJoystick.ino
+++ b/examples/Shifter/ShiftJoystick/ShiftJoystick.ino
@@ -21,7 +21,7 @@
  */
 
  /**
- * @brief   Emulates the shifter as a joystick over USB.
+ * @details Emulates the shifter as a joystick over USB.
  * @example ShiftJoystick.ino
  */
 

--- a/examples/Shifter/ShiftPrint/ShiftPrint.ino
+++ b/examples/Shifter/ShiftPrint/ShiftPrint.ino
@@ -21,7 +21,7 @@
  */
 
  /**
- * @brief   Reads and prints the current gear over serial.
+ * @details Reads and prints the current gear over serial.
  * @example ShiftPrint.ino
  */
 


### PR DESCRIPTION
Two small Doxygen-related fixes.

First, enables autobrief so that all of the thorough documentation is properly split into brief and detail sections. Oops.

Second, changes the \brief command to \details for all of the examples, to fix double-printing text on the example pages.