### PR TITLE
Unused pin rework

### DIFF
--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -161,7 +161,7 @@ static void readFloat(float& value, Stream& client) {
 //                  DeviceConnection                      #
 //#########################################################
 
-DeviceConnection::DeviceConnection(uint8_t pin, bool invert, unsigned long detectTime)
+DeviceConnection::DeviceConnection(PinNum pin, bool invert, unsigned long detectTime)
 	:
 	Pin(pin), Inverted(invert), stablePeriod(detectTime),  // constants(ish)
 
@@ -258,7 +258,7 @@ bool DeviceConnection::readPin() const {
 //#########################################################
 
 
-AnalogInput::AnalogInput(uint8_t p)
+AnalogInput::AnalogInput(PinNum p)
 	: Pin(p), position(AnalogInput::Min), cal({AnalogInput::Min, AnalogInput::Max})
 {
 	if (Pin != NOT_A_PIN) {
@@ -333,7 +333,7 @@ void AnalogInput::setCalibration(AnalogInput::Calibration newCal) {
 //                       Pedals                           #
 //#########################################################
 
-Pedals::Pedals(AnalogInput* dataPtr, uint8_t nPedals, uint8_t detectPin)
+Pedals::Pedals(AnalogInput* dataPtr, uint8_t nPedals, PinNum detectPin)
 	: 
 	pedalData(dataPtr),
 	NumPedals(nPedals),
@@ -538,7 +538,7 @@ void Pedals::serialCalibration(Stream& iface) {
 }
 
 
-TwoPedals::TwoPedals(uint8_t gasPin, uint8_t brakePin, uint8_t detectPin)
+TwoPedals::TwoPedals(PinNum gasPin, PinNum brakePin, PinNum detectPin)
 	: Pedals(pedalData, NumPedals, detectPin),
 	pedalData{ AnalogInput(gasPin), AnalogInput(brakePin) }
 {}
@@ -549,7 +549,7 @@ void TwoPedals::setCalibration(AnalogInput::Calibration gasCal, AnalogInput::Cal
 }
 
 
-ThreePedals::ThreePedals(uint8_t gasPin, uint8_t brakePin, uint8_t clutchPin, uint8_t detectPin)
+ThreePedals::ThreePedals(PinNum gasPin, PinNum brakePin, PinNum clutchPin, PinNum detectPin)
 	: Pedals(pedalData, NumPedals, detectPin),
 	pedalData{ AnalogInput(gasPin), AnalogInput(brakePin), AnalogInput(clutchPin) }
 {}
@@ -562,7 +562,7 @@ void ThreePedals::setCalibration(AnalogInput::Calibration gasCal, AnalogInput::C
 
 
 
-LogitechPedals::LogitechPedals(uint8_t gasPin, uint8_t brakePin, uint8_t clutchPin, uint8_t detectPin)
+LogitechPedals::LogitechPedals(PinNum gasPin, PinNum brakePin, PinNum clutchPin, PinNum detectPin)
 	: ThreePedals(gasPin, brakePin, clutchPin, detectPin)
 {
 	// taken from calibrating my own pedals. the springs are pretty stiff so while
@@ -571,7 +571,7 @@ LogitechPedals::LogitechPedals(uint8_t gasPin, uint8_t brakePin, uint8_t clutchP
 	this->setCalibration({ 904, 48 }, { 944, 286 }, { 881, 59 });
 }
 
-LogitechDrivingForceGT_Pedals::LogitechDrivingForceGT_Pedals(uint8_t gasPin, uint8_t brakePin, uint8_t detectPin)
+LogitechDrivingForceGT_Pedals::LogitechDrivingForceGT_Pedals(PinNum gasPin, PinNum brakePin, PinNum detectPin)
 	: TwoPedals(gasPin, brakePin, detectPin)
 {
 	this->setCalibration({ 646, 0 }, { 473, 1023 });  // taken from calibrating my own pedals
@@ -657,7 +657,7 @@ const float AnalogShifter::CalEngagementPoint = 0.70;
 const float AnalogShifter::CalReleasePoint = 0.50;
 const float AnalogShifter::CalEdgeOffset = 0.60;
 
-AnalogShifter::AnalogShifter(uint8_t pinX, uint8_t pinY, uint8_t pinRev, uint8_t detectPin)
+AnalogShifter::AnalogShifter(PinNum pinX, PinNum pinY, PinNum pinRev, PinNum detectPin)
 	: 
 	/* In initializing the Shifter, the lowest gear is going to be '-1' if a pin
 	* exists for reverse, otherwise it's going to be '0' (neutral).
@@ -977,7 +977,7 @@ void AnalogShifter::serialCalibration(Stream& iface) {
 	iface.println(F("\n\nCalibration complete! :)\n"));
 }
 
-LogitechShifter::LogitechShifter(uint8_t pinX, uint8_t pinY, uint8_t pinRev, uint8_t detectPin)
+LogitechShifter::LogitechShifter(PinNum pinX, PinNum pinY, PinNum pinRev, PinNum detectPin)
 	: AnalogShifter(pinX, pinY, pinRev, detectPin)
 {
 	this->setCalibration({ 490, 440 }, { 253, 799 }, { 262, 86 }, { 460, 826 }, { 470, 76 }, { 664, 841 }, { 677, 77 });
@@ -987,7 +987,7 @@ LogitechShifter::LogitechShifter(uint8_t pinX, uint8_t pinY, uint8_t pinRev, uin
 //                      Handbrake                         #
 //#########################################################
 
-Handbrake::Handbrake(uint8_t pinAx, uint8_t detectPin) 
+Handbrake::Handbrake(PinNum pinAx, PinNum detectPin)
 	: 
 	analogAxis(pinAx),
 	detector(detectPin),

--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -248,7 +248,7 @@ void DeviceConnection::setStablePeriod(unsigned long t) {
 }
 
 bool DeviceConnection::readPin() const {
-	if (Pin == NOT_A_PIN) return HIGH;  // if no pin is set, we're always connected
+	if (Pin == UnusedPin) return HIGH;  // if no pin is set, we're always connected
 	const bool state = digitalRead(Pin);
 	return Inverted ? !state : state;
 }
@@ -261,7 +261,7 @@ bool DeviceConnection::readPin() const {
 AnalogInput::AnalogInput(PinNum p)
 	: Pin(p), position(AnalogInput::Min), cal({AnalogInput::Min, AnalogInput::Max})
 {
-	if (Pin != NOT_A_PIN) {
+	if (Pin != UnusedPin) {
 		pinMode(Pin, INPUT);
 	}
 }
@@ -269,7 +269,7 @@ AnalogInput::AnalogInput(PinNum p)
 bool AnalogInput::read() {
 	bool changed = false;
 
-	if (Pin != NOT_A_PIN) {
+	if (Pin != UnusedPin) {
 		const int previous = this->position;
 		this->position = analogRead(Pin);
 
@@ -662,7 +662,7 @@ AnalogShifter::AnalogShifter(PinNum pinX, PinNum pinY, PinNum pinRev, PinNum det
 	/* In initializing the Shifter, the lowest gear is going to be '-1' if a pin
 	* exists for reverse, otherwise it's going to be '0' (neutral).
 	*/
-	Shifter(pinRev != NOT_A_PIN ? -1 : 0, 6),
+	Shifter(pinRev != UnusedPin ? -1 : 0, 6),
 
 	/* Two axes, X and Y */
 	analogAxis{ AnalogInput(pinX), AnalogInput(pinY) },
@@ -777,7 +777,7 @@ int AnalogShifter::getPositionRaw(Axis ax) const {
 bool AnalogShifter::getReverseButton() const {
 	// if the reverse pin is not set *or* if the device is not currently
 	// connected, avoid reading the floating input and just return 'false'
-	if (PinReverse == NOT_A_PIN || detector.getState() != DeviceConnection::Connected) {
+	if (PinReverse == UnusedPin || detector.getState() != DeviceConnection::Connected) {
 		return false;
 	}
 	return digitalRead(PinReverse);

--- a/src/SimRacing.h
+++ b/src/SimRacing.h
@@ -120,13 +120,13 @@ namespace SimRacing {
 		*/
 		bool readPin() const;
 
-		const PinNum Pin;            ///< The pin number being read from. Can be 'UnusedPin' to disable
-		const bool Inverted;         ///< Whether the input is inverted, so 'LOW' is detected instead of 'HIGH'
+		PinNum pin;                  ///< The pin number being read from. Can be 'UnusedPin' to disable
+		bool inverted;               ///< Whether the input is inverted, so 'LOW' is detected instead of 'HIGH'
 		unsigned long stablePeriod;  ///< The amount of time the input must be stable for (ms)
 
-		ConnectionState state;     ///< The current state of the connection
-		bool pinState;             ///< Buffered state of the input pin, accounting for inversion
-		unsigned long lastChange;  ///< Timestamp of the last pin change, in ms (using millis())
+		ConnectionState state;       ///< The current state of the connection
+		bool pinState;               ///< Buffered state of the input pin, accounting for inversion
+		unsigned long lastChange;    ///< Timestamp of the last pin change, in ms (using millis())
 	};
 
 
@@ -141,9 +141,9 @@ namespace SimRacing {
 		/**
 		* Class constructor
 		*
-		* @param p the I/O pin for this input (Arduino numbering)
+		* @param pin the I/O pin for this input (Arduino numbering)
 		*/
-		AnalogInput(PinNum p);
+		AnalogInput(PinNum pin);
 
 		/**
 		* Updates the current value of the axis by polling the ADC
@@ -237,9 +237,9 @@ namespace SimRacing {
 		void setCalibration(Calibration newCal);
 
 	private:
-		const PinNum Pin = UnusedPin;   ///< the digital pin number for this input
-		int position;                   ///< the axis' position in its range, buffered
-		Calibration cal;                ///< the calibration values for the axis
+		PinNum pin;              ///< the digital pin number for this input
+		int position;            ///< the axis' position in its range, buffered
+		Calibration cal;         ///< the calibration values for the axis
 	};
 
 
@@ -393,11 +393,11 @@ namespace SimRacing {
 		/**
 		* Class constructor
 		*
-		* @param gasPin the analog pin for the gas pedal potentiometer
-		* @param brakePin the analog pin for the brake pedal potentiometer
-		* @param detectPin the digital pin for device detection (high is detected)
+		* @param pinGas    the analog pin for the gas pedal potentiometer
+		* @param pinBrake  the analog pin for the brake pedal potentiometer
+		* @param pinDetect the digital pin for device detection (high is detected)
 		*/
-		TwoPedals(PinNum gasPin, PinNum brakePin, PinNum detectPin = UnusedPin);
+		TwoPedals(PinNum pinGas, PinNum pinBrake, PinNum pinDetect = UnusedPin);
 
 		/**
 		* Sets the calibration data (min/max) for the pedals
@@ -421,12 +421,12 @@ namespace SimRacing {
 		/**
 		* Class constructor
 		* 
-		* @param gasPin the analog pin for the gas pedal potentiometer
-		* @param brakePin the analog pin for the brake pedal potentiometer
-		* @param clutchPin the analog pin for the clutch pedal potentiometer
-		* @param detectPin the digital pin for device detection (high is detected)
+		* @param pinGas    the analog pin for the gas pedal potentiometer
+		* @param pinBrake  the analog pin for the brake pedal potentiometer
+		* @param pinClutch the analog pin for the clutch pedal potentiometer
+		* @param pinDetect the digital pin for device detection (high is detected)
 		*/
-		ThreePedals(PinNum gasPin, PinNum brakePin, PinNum clutchPin, PinNum detectPin = UnusedPin);
+		ThreePedals(PinNum pinGas, PinNum pinBrake, PinNum pinClutch, PinNum pinDetect = UnusedPin);
 
 		/**
 		* Sets the calibration data (min/max) for the pedals
@@ -552,9 +552,9 @@ namespace SimRacing {
 		* @param pinX the analog input pin for the X axis
 		* @param pinY the analog input pin for the Y axis
 		* @param pinRev the digital input pin for the 'reverse' button
-		* @param detectPin the digital pin for device detection (high is detected)
+		* @param pinDetect the digital pin for device detection (high is detected)
 		*/
-		AnalogShifter(PinNum pinX, PinNum pinY, PinNum pinRev = UnusedPin, PinNum detectPin = UnusedPin);
+		AnalogShifter(PinNum pinX, PinNum pinY, PinNum pinRev = UnusedPin, PinNum pinDetect = UnusedPin);
 
 		/**
 		* Initializes the hardware pins for reading the gear states.
@@ -675,7 +675,7 @@ namespace SimRacing {
 		} calibration;
 
 		AnalogInput analogAxis[2];  ///< Axis data for X and Y
-		const PinNum PinReverse;   ///< The pin for the reverse gear button
+		PinNum pinReverse;          ///< The pin for the reverse gear button
 		DeviceConnection detector;  ///< detector instance for checking if the shifter is connected
 	};
 
@@ -691,9 +691,9 @@ namespace SimRacing {
 		* Class constructor
 		*
 		* @param pinAx analog pin number for the handbrake axis
-		* @param detectPin the digital pin for device detection (high is detected)
+		* @param pinDetect the digital pin for device detection (high is detected)
 		*/
-		Handbrake(PinNum pinAx, PinNum detectPin = UnusedPin);
+		Handbrake(PinNum pinAx, PinNum pinDetect = UnusedPin);
 
 		/**
 		* Initializes the pin for reading from the handbrake.
@@ -760,7 +760,7 @@ namespace SimRacing {
 	class LogitechPedals : public ThreePedals {
 	public:
 		/** @copydoc ThreePedals::ThreePedals */
-		LogitechPedals(PinNum gasPin, PinNum brakePin, PinNum clutchPin, PinNum detectPin = UnusedPin);
+		LogitechPedals(PinNum pinGas, PinNum pinBrake, PinNum pinClutch, PinNum pinDetect = UnusedPin);
 	};
 
 	/**
@@ -775,7 +775,7 @@ namespace SimRacing {
 	class LogitechDrivingForceGT_Pedals : public TwoPedals {
 	public:
 		/** @copydoc TwoPedals::TwoPedals */
-		LogitechDrivingForceGT_Pedals(PinNum gasPin, PinNum brakePin, PinNum detectPin = UnusedPin);
+		LogitechDrivingForceGT_Pedals(PinNum pinGas, PinNum pinBrake, PinNum pinDetect = UnusedPin);
 	};
 
 	/**
@@ -787,7 +787,7 @@ namespace SimRacing {
 	class LogitechShifter : public AnalogShifter {
 	public:
 		/** @copydoc AnalogShifter::AnalogShifter */
-		LogitechShifter(PinNum pinX, PinNum pinY, PinNum pinRev = UnusedPin, PinNum detectPin = UnusedPin);
+		LogitechShifter(PinNum pinX, PinNum pinY, PinNum pinRev = UnusedPin, PinNum pinDetect = UnusedPin);
 	};
 
 

--- a/src/SimRacing.h
+++ b/src/SimRacing.h
@@ -34,7 +34,13 @@ namespace SimRacing {
 	/**
 	* Type alias for pin numbers, using Arduino numbering
 	*/
-	using PinNum = uint8_t;
+	using PinNum = int16_t;
+
+	/**
+	* Dummy pin number signaling that a pin is unused
+	* and can be safely ignored
+	*/
+	const PinNum UnusedPin = -1;
 
 
 	/**
@@ -69,7 +75,7 @@ namespace SimRacing {
 		/**
 		* Class constructor
 		*
-		* @param pin the pin number being read. Can be 'NOT_A_PIN' to disable.
+		* @param pin the pin number being read. Can be 'UnusedPin' to disable.
 		* @param invert whether the input is inverted, so 'LOW' is detected instead of 'HIGH'
 		* @param detectTime the amount of time, in ms, the input must be stable for
 		*        before it's interpreted as 'detected'
@@ -114,7 +120,7 @@ namespace SimRacing {
 		*/
 		bool readPin() const;
 
-		const PinNum Pin;            ///< The pin number being read from. Can be 'NOT_A_PIN' to disable
+		const PinNum Pin;            ///< The pin number being read from. Can be 'UnusedPin' to disable
 		const bool Inverted;         ///< Whether the input is inverted, so 'LOW' is detected instead of 'HIGH'
 		unsigned long stablePeriod;  ///< The amount of time the input must be stable for (ms)
 
@@ -231,7 +237,7 @@ namespace SimRacing {
 		void setCalibration(Calibration newCal);
 
 	private:
-		const PinNum Pin = NOT_A_PIN;   ///< the digital pin number for this input
+		const PinNum Pin = UnusedPin;   ///< the digital pin number for this input
 		int position;                   ///< the axis' position in its range, buffered
 		Calibration cal;                ///< the calibration values for the axis
 	};
@@ -391,7 +397,7 @@ namespace SimRacing {
 		* @param brakePin the analog pin for the brake pedal potentiometer
 		* @param detectPin the digital pin for device detection (high is detected)
 		*/
-		TwoPedals(PinNum gasPin, PinNum brakePin, PinNum detectPin = NOT_A_PIN);
+		TwoPedals(PinNum gasPin, PinNum brakePin, PinNum detectPin = UnusedPin);
 
 		/**
 		* Sets the calibration data (min/max) for the pedals
@@ -420,7 +426,7 @@ namespace SimRacing {
 		* @param clutchPin the analog pin for the clutch pedal potentiometer
 		* @param detectPin the digital pin for device detection (high is detected)
 		*/
-		ThreePedals(PinNum gasPin, PinNum brakePin, PinNum clutchPin, PinNum detectPin = NOT_A_PIN);
+		ThreePedals(PinNum gasPin, PinNum brakePin, PinNum clutchPin, PinNum detectPin = UnusedPin);
 
 		/**
 		* Sets the calibration data (min/max) for the pedals
@@ -548,7 +554,7 @@ namespace SimRacing {
 		* @param pinRev the digital input pin for the 'reverse' button
 		* @param detectPin the digital pin for device detection (high is detected)
 		*/
-		AnalogShifter(PinNum pinX, PinNum pinY, PinNum pinRev = NOT_A_PIN, PinNum detectPin = NOT_A_PIN);
+		AnalogShifter(PinNum pinX, PinNum pinY, PinNum pinRev = UnusedPin, PinNum detectPin = UnusedPin);
 
 		/**
 		* Initializes the hardware pins for reading the gear states.
@@ -687,7 +693,7 @@ namespace SimRacing {
 		* @param pinAx analog pin number for the handbrake axis
 		* @param detectPin the digital pin for device detection (high is detected)
 		*/
-		Handbrake(PinNum pinAx, PinNum detectPin = NOT_A_PIN);
+		Handbrake(PinNum pinAx, PinNum detectPin = UnusedPin);
 
 		/**
 		* Initializes the pin for reading from the handbrake.
@@ -754,7 +760,7 @@ namespace SimRacing {
 	class LogitechPedals : public ThreePedals {
 	public:
 		/** @copydoc ThreePedals::ThreePedals */
-		LogitechPedals(PinNum gasPin, PinNum brakePin, PinNum clutchPin, PinNum detectPin = NOT_A_PIN);
+		LogitechPedals(PinNum gasPin, PinNum brakePin, PinNum clutchPin, PinNum detectPin = UnusedPin);
 	};
 
 	/**
@@ -769,7 +775,7 @@ namespace SimRacing {
 	class LogitechDrivingForceGT_Pedals : public TwoPedals {
 	public:
 		/** @copydoc TwoPedals::TwoPedals */
-		LogitechDrivingForceGT_Pedals(PinNum gasPin, PinNum brakePin, PinNum detectPin = NOT_A_PIN);
+		LogitechDrivingForceGT_Pedals(PinNum gasPin, PinNum brakePin, PinNum detectPin = UnusedPin);
 	};
 
 	/**
@@ -781,7 +787,7 @@ namespace SimRacing {
 	class LogitechShifter : public AnalogShifter {
 	public:
 		/** @copydoc AnalogShifter::AnalogShifter */
-		LogitechShifter(PinNum pinX, PinNum pinY, PinNum pinRev = NOT_A_PIN, PinNum detectPin = NOT_A_PIN);
+		LogitechShifter(PinNum pinX, PinNum pinY, PinNum pinRev = UnusedPin, PinNum detectPin = UnusedPin);
 	};
 
 

--- a/src/SimRacing.h
+++ b/src/SimRacing.h
@@ -32,6 +32,12 @@
 
 namespace SimRacing {
 	/**
+	* Type alias for pin numbers, using Arduino numbering
+	*/
+	using PinNum = uint8_t;
+
+
+	/**
 	* Enumeration for analog axis names, mapped to integers
 	*/
 	enum Axis : uint8_t {
@@ -68,7 +74,7 @@ namespace SimRacing {
 		* @param detectTime the amount of time, in ms, the input must be stable for
 		*        before it's interpreted as 'detected'
 		*/
-		DeviceConnection(uint8_t pin, bool invert = false, unsigned long detectTime = 250);
+		DeviceConnection(PinNum pin, bool invert = false, unsigned long detectTime = 250);
 
 		/**
 		* Checks if the pin detects a connection. This polls the input and checks
@@ -108,7 +114,7 @@ namespace SimRacing {
 		*/
 		bool readPin() const;
 
-		const uint8_t Pin;           ///< The pin number being read from. Can be 'NOT_A_PIN' to disable
+		const PinNum Pin;            ///< The pin number being read from. Can be 'NOT_A_PIN' to disable
 		const bool Inverted;         ///< Whether the input is inverted, so 'LOW' is detected instead of 'HIGH'
 		unsigned long stablePeriod;  ///< The amount of time the input must be stable for (ms)
 
@@ -131,7 +137,7 @@ namespace SimRacing {
 		*
 		* @param p the I/O pin for this input (Arduino numbering)
 		*/
-		AnalogInput(uint8_t p);
+		AnalogInput(PinNum p);
 
 		/**
 		* Updates the current value of the axis by polling the ADC
@@ -225,7 +231,7 @@ namespace SimRacing {
 		void setCalibration(Calibration newCal);
 
 	private:
-		const uint8_t Pin = NOT_A_PIN;  ///< the digital pin number for this input
+		const PinNum Pin = NOT_A_PIN;   ///< the digital pin number for this input
 		int position;                   ///< the axis' position in its range, buffered
 		Calibration cal;                ///< the calibration values for the axis
 	};
@@ -285,7 +291,7 @@ namespace SimRacing {
 		* @param nPedals the number of pedals stored in said data pointer
 		* @param detectPin the digital pin for device detection (high is detected)
 		*/
-		Pedals(AnalogInput* dataPtr, uint8_t nPedals, uint8_t detectPin);
+		Pedals(AnalogInput* dataPtr, uint8_t nPedals, PinNum detectPin);
 
 		/** @copydoc Peripheral::begin() */
 		virtual void begin();
@@ -385,7 +391,7 @@ namespace SimRacing {
 		* @param brakePin the analog pin for the brake pedal potentiometer
 		* @param detectPin the digital pin for device detection (high is detected)
 		*/
-		TwoPedals(uint8_t gasPin, uint8_t brakePin, uint8_t detectPin = NOT_A_PIN);
+		TwoPedals(PinNum gasPin, PinNum brakePin, PinNum detectPin = NOT_A_PIN);
 
 		/**
 		* Sets the calibration data (min/max) for the pedals
@@ -414,7 +420,7 @@ namespace SimRacing {
 		* @param clutchPin the analog pin for the clutch pedal potentiometer
 		* @param detectPin the digital pin for device detection (high is detected)
 		*/
-		ThreePedals(uint8_t gasPin, uint8_t brakePin, uint8_t clutchPin, uint8_t detectPin = NOT_A_PIN);
+		ThreePedals(PinNum gasPin, PinNum brakePin, PinNum clutchPin, PinNum detectPin = NOT_A_PIN);
 
 		/**
 		* Sets the calibration data (min/max) for the pedals
@@ -542,7 +548,7 @@ namespace SimRacing {
 		* @param pinRev the digital input pin for the 'reverse' button
 		* @param detectPin the digital pin for device detection (high is detected)
 		*/
-		AnalogShifter(uint8_t pinX, uint8_t pinY, uint8_t pinRev = NOT_A_PIN, uint8_t detectPin = NOT_A_PIN);
+		AnalogShifter(PinNum pinX, PinNum pinY, PinNum pinRev = NOT_A_PIN, PinNum detectPin = NOT_A_PIN);
 
 		/**
 		* Initializes the hardware pins for reading the gear states.
@@ -663,7 +669,7 @@ namespace SimRacing {
 		} calibration;
 
 		AnalogInput analogAxis[2];  ///< Axis data for X and Y
-		const uint8_t PinReverse;   ///< The pin for the reverse gear button
+		const PinNum PinReverse;   ///< The pin for the reverse gear button
 		DeviceConnection detector;  ///< detector instance for checking if the shifter is connected
 	};
 
@@ -681,7 +687,7 @@ namespace SimRacing {
 		* @param pinAx analog pin number for the handbrake axis
 		* @param detectPin the digital pin for device detection (high is detected)
 		*/
-		Handbrake(uint8_t pinAx, uint8_t detectPin = NOT_A_PIN);
+		Handbrake(PinNum pinAx, PinNum detectPin = NOT_A_PIN);
 
 		/**
 		* Initializes the pin for reading from the handbrake.
@@ -748,7 +754,7 @@ namespace SimRacing {
 	class LogitechPedals : public ThreePedals {
 	public:
 		/** @copydoc ThreePedals::ThreePedals */
-		LogitechPedals(uint8_t gasPin, uint8_t brakePin, uint8_t clutchPin, uint8_t detectPin = NOT_A_PIN);
+		LogitechPedals(PinNum gasPin, PinNum brakePin, PinNum clutchPin, PinNum detectPin = NOT_A_PIN);
 	};
 
 	/**
@@ -763,7 +769,7 @@ namespace SimRacing {
 	class LogitechDrivingForceGT_Pedals : public TwoPedals {
 	public:
 		/** @copydoc TwoPedals::TwoPedals */
-		LogitechDrivingForceGT_Pedals(uint8_t gasPin, uint8_t brakePin, uint8_t detectPin = NOT_A_PIN);
+		LogitechDrivingForceGT_Pedals(PinNum gasPin, PinNum brakePin, PinNum detectPin = NOT_A_PIN);
 	};
 
 	/**
@@ -775,7 +781,7 @@ namespace SimRacing {
 	class LogitechShifter : public AnalogShifter {
 	public:
 		/** @copydoc AnalogShifter::AnalogShifter */
-		LogitechShifter(uint8_t pinX, uint8_t pinY, uint8_t pinRev = NOT_A_PIN, uint8_t detectPin = NOT_A_PIN);
+		LogitechShifter(PinNum pinX, PinNum pinY, PinNum pinRev = NOT_A_PIN, PinNum detectPin = NOT_A_PIN);
 	};
 
 


### PR DESCRIPTION
This PR changes the way pins are handled internally with the library.

* All pins now use the `PinNum` type, rather than `uint8_t`. This makes it more obvious what each argument expects and allows for changing all pin types together. The `PinNum` type is currently `int16_t`.
* All `NOT_A_PIN` references, which used the macro from the AVR core, have been replaced with a new constant, `UnusedPin`. The `NOT_A_PIN` macro wasn't really meant for this usage, and this change makes the library more portable.
* Pin assignments are now sanitized, so that invalid (i.e. negative) pin numbers will be caught and changed to `UnusedPin`.
* Argument names for pins have been refactored to all use 'pin' as a prefix, rather than a mix of prefix and suffix as before.
* Pin number constants as class members have been changed to be mutable, to allow for copying.

The end result is (hopefully) that pins which are unused are more robustly ignored, and the library is more portable.