### PR TITLE
Fix Logitech G25 Sequential Shifting Direction

### DIFF
--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -1528,17 +1528,16 @@ void LogitechShifterG25::setCalibrationSequential(int neutral, int up, int down,
 
 	// if up/down calibration points are reversed, swap them
 	//
-	// in v2 of the library, pushing the shifter was 'shift up' and pulling the
-	// shifter was 'shift down'
+	// in the original public release, pushing the shifter was 'shift up'
+	// and pulling the shifter was 'shift down'
 	//
-	// in v3 of the library this was fixed, so that pushing the shifter is
-	// 'shift down' and pulling the shifter is 'shift up', matching the
-	// markings on the shifter itself (or mine, at least). this also matches
-	// the behavior of a sequential shift lever in a real rally car
+	// this bug was eventually fixed, so that now pushing the shifter is
+	// 'shift down' and pulling the shifter is 'shift up'. This matches the
+	// markings on the shifter itself (or mine, at least), and mirrors the
+	// behavior of a sequential shift lever in a real rally car.
 	//
 	// by swapping the calibration points here, the function maintains
-	// compatibility with calibration lines written for both version of
-	// the library
+	// compatibility with calibration lines written for both versions
 	if(up > down) {
 		int temp = up;
 		up = down;  // dogs and cats living together, mass hysteria

--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -1626,7 +1626,12 @@ void LogitechShifterG25::serialCalibrationSequential(Stream& iface) {
 
 		this->update();
 		data[i] = this->getPositionRaw(Axis::Y);
-		iface.println();  // spacing
+
+		iface.print(F("Shifter position recorded as "));
+		iface.print('\'');
+		iface.print(data[i]);
+		iface.print('\'');
+		iface.println('\n');  // spacing
 	}
 
 	iface.println(F("These settings are optional. Send 'y' to customize. Send any other character to continue with the default values."));

--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -1103,7 +1103,7 @@ void AnalogShifter::serialCalibration(Stream& iface) {
 	iface.println(separator);
 	iface.println();
 
-	iface.print(F("shifter.setCalibration( "));
+	iface.print(F("shifter.setCalibration("));
 
 	for (int i = 0; i < 7; i++) {
 		iface.print('{');
@@ -1665,7 +1665,7 @@ void LogitechShifterG25::serialCalibrationSequential(Stream& iface) {
 	iface.println(separator);
 	iface.println();
 
-	iface.print(F("shifter.setCalibrationSequential( "));
+	iface.print(F("shifter.setCalibrationSequential("));
 
 	iface.print(neutral);
 	iface.print(", ");

--- a/src/SimRacing.cpp
+++ b/src/SimRacing.cpp
@@ -1601,8 +1601,8 @@ void LogitechShifterG25::serialCalibrationSequential(Stream& iface) {
 
 	const uint8_t NumPoints = 3;
 	const char* directions[2][2] = {
-		{ "towards you", "up" },
-		{ "away from you", "down" },
+		{ "pull", "towards you" },
+		{ "push", "away from you" },
 	};
 	int data[NumPoints];
 
@@ -1615,9 +1615,9 @@ void LogitechShifterG25::serialCalibrationSequential(Stream& iface) {
 			iface.print(F("Leave the gear shifter in neutral"));
 		}
 		else {
-			iface.print(F("Please move the gear shifter "));
+			iface.print(F("Please "));
 			iface.print(directions[i - 1][0]);
-			iface.print(F(" to sequentially shift "));
+			iface.print(F(" the gear shifter "));
 			iface.print(directions[i - 1][1]);
 			iface.print(F(" and hold it there"));
 		}

--- a/src/SimRacing.h
+++ b/src/SimRacing.h
@@ -1154,18 +1154,24 @@ namespace SimRacing {
 		bool inSequentialMode() const;
 
 		/**
-		* Check if the sequential shifter is shifted up
+		* Check if the sequential shifter is in the shift up position
+		*
+		* When in sequential mode, the shifter is considered to be in the
+		* "shift up" position when it is pulled towards the user.
 		* 
-		* @returns 'true' if the sequential shifter is shifted up,
-		*          'false' otherwise
+		* @returns 'true' if the sequential shifter is in the shift up
+		*          position, 'false' otherwise
 		*/
 		bool getShiftUp() const;
 
 		/**
-		* Check if the sequential shifter is shifted down
+		* Check if the sequential shifter is in the shift down position
 		*
-		* @returns 'true' if the sequential shifter is shifted down,
-		*          'false' otherwise
+		* When in sequential mode, the shifter is considered to be in the
+		* "shift down" position when it is pushed away from the user.
+		*
+		* @returns 'true' if the sequential shifter is in the shift down
+		*          position, 'false' otherwise
 		*/
 		bool getShiftDown() const;
 


### PR DESCRIPTION
Per comments in #21, the Logitech G25 shifter's sequential shifting mode was incorrectly set up so that pushing the shifter away shifted up, and pulling the shifter shifted down. This fixes the implementation so that pulling the shifter shifts up, and pushing the shifter shifts down. This matches the printed marking on my own shifter, as well as real-world sequential lever shifters in rally cars.

I've also added clarifying comments in the `LogitechShifterG25` class to that effect, and improved the wording for the sequential shifting interactive calibration.